### PR TITLE
Replaced Depricated tf.contrib.deprecated.scalar_summary with tf.compat.v1.summary.scalar

### DIFF
--- a/code/cifar_train_baseline.py
+++ b/code/cifar_train_baseline.py
@@ -247,6 +247,7 @@ def train_inception_baseline(max_step_run):
           labels=one_hot_labels, logits=logits)
       total_loss = tf.reduce_mean(total_loss)
 
+      # Using latest Protobuf Summary.
       tf.compat.v1.summary.scalar('Total Loss', total_loss)
 
       decay_steps = int(

--- a/code/cifar_train_baseline.py
+++ b/code/cifar_train_baseline.py
@@ -247,7 +247,7 @@ def train_inception_baseline(max_step_run):
           labels=one_hot_labels, logits=logits)
       total_loss = tf.reduce_mean(total_loss)
 
-      # Using latest Protobuf Summary.
+      # Using latest tensorflow ProtoBuf.
       tf.compat.v1.summary.scalar('Total Loss', total_loss)
 
       decay_steps = int(

--- a/code/cifar_train_baseline.py
+++ b/code/cifar_train_baseline.py
@@ -247,7 +247,7 @@ def train_inception_baseline(max_step_run):
           labels=one_hot_labels, logits=logits)
       total_loss = tf.reduce_mean(total_loss)
 
-      tf.contrib.deprecated.scalar_summary('Total Loss', total_loss)
+      tf.compat.v1.summary.scalar('Total Loss', total_loss)
 
       decay_steps = int(
           num_samples_per_epoch / FLAGS.batch_size * FLAGS.num_epochs_per_decay)

--- a/code/resnet_model.py
+++ b/code/resnet_model.py
@@ -124,7 +124,7 @@ class ResNet(object):
   def _build_train_op(self):
     """Build training specific ops for the graph."""
     self.lrn_rate = tf.constant(self.hps.lrn_rate, tf.float32)
-    tf.contrib.deprecated.scalar_summary('learning rate', self.lrn_rate)
+    tf.compat.v1.summary.scalar('learning rate', self.lrn_rate)
 
     trainable_variables = tf.trainable_variables()
     grads = tf.gradients(self.cost, trainable_variables)


### PR DESCRIPTION
This is slight change in the Summary ProtoBuf. Initially the project writers have used deprecated method **scalar_summary()** of **tf.contrib.deprecated**. But since, It may be excluded in upcomming version of tensorflow. @roadjiang sir, please review this PR.
Thank you for this awesome project. It helped me very much in my work. This also tends to work with Conventional Deep Neural Nets with structured data.